### PR TITLE
nga logs for galaxy_stats disabled. There are already telegraf logs t…

### DIFF
--- a/env/common/group_vars/galaxy.yml
+++ b/env/common/group_vars/galaxy.yml
@@ -289,7 +289,7 @@ telegraf_plugins_extra:
   galaxy_misc_stats:
     plugin: "exec"
     config:
-      - commands = ["/srv/nga/venv/bin/python3 /srv/nga/galaxy_stats.py -c /srv/nga/configs/nga-server.json -l /var/log/nga/galaxy_stats.log stats"]
+      - commands = ["/srv/nga/venv/bin/python3 /srv/nga/galaxy_stats.py -c /srv/nga/configs/nga-server.json stats"]
       - timeout = "15s"
       - data_format = "influx"
       - interval = "1m"


### PR DESCRIPTION
…hemselves.